### PR TITLE
More concise syntax

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -1,15 +1,13 @@
 #!/bin/sh
-
-EVROOT="/Applications/EV Nova.app/Contents/MacOS/"
+WD=`dirname "$0"`
 EVBIN="Ev Nova"
 
 export DYLD_FORCE_FLAT_NAMESPACE=1
+export DYLD_INSERT_LIBRARIES="$WD/libNova.A.dylib"
 
-if [ -e "${EVROOT}/${EVBIN}.original" ]
+if [ -e "$WD/$EVBIN.original" ]
 then
-	export DYLD_INSERT_LIBRARIES=${EVROOT}/libNova.A.dylib
-	"${EVROOT}/${EVBIN}.original"
+	"$WD/$EVBIN.original"
 else
-	export DYLD_INSERT_LIBRARIES=`dirname $0`/libNova.A.dylib
-	"${EVROOT}/${EVBIN}"
+	"/Applications/EV Nova.app/Contents/MacOS/$EVBIN"
 fi


### PR DESCRIPTION
Smaller, slimmer, works better. The script should ALWAYS be in the same directory as "$EVBIN.original" because that's how the makefile sets things up. It is safe to assume that if $EVBIN.original exists, we can use the current path to the script as the base path, which is what `dirname $0` gets us.
