### PR TITLE
Prevent overwriting of original binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,19 @@ OBJS=spi.o
 CFLAGS+=-arch i386
 LDFLAGS+=-dynamiclib -arch i386
 LIB=libNova.A.dylib
-EVROOT="/Applications/EV Nova.app/Contents/MacOS/"
+EVROOT="/Applications/EV Nova.app/Contents/MacOS"
 EVBIN="Ev Nova"
 LAUNCHER=launcher.sh
+EVBIN_ORIG="Ev Nova.original"
 
 $(LIB): $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) -o $(LIB)
 
 install: $(LIB)
-	mv $(EVROOT)/$(EVBIN) $(EVROOT)/$(EVBIN).original
+	if [ ! -e $(EVROOT)/$(EVBIN_ORIG) ];\
+	then\
+		mv $(EVROOT)/$(EVBIN) $(EVROOT)/$(EVBIN_ORIG);\
+	fi;
 	install $(LAUNCHER) $(EVROOT)/$(EVBIN)
 	install $(LIB) $(EVROOT)
 


### PR DESCRIPTION
This will prevent the Makefile from overwriting the original binary, if install is run a second time.
