### PR TITLE
Prevent overwrite of original binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,25 @@ OBJS=spi.o
 CFLAGS+=-arch i386
 LDFLAGS+=-dynamiclib -arch i386
 LIB=libNova.A.dylib
-EVROOT="/Applications/EV Nova.app/Contents/MacOS/"
+EVROOT="/Applications/EV Nova.app/Contents/MacOS"
 EVBIN="Ev Nova"
 LAUNCHER=launcher.sh
+EVBIN_ORIG="Ev Nova.original"
 
 $(LIB): $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) -o $(LIB)
+        $(CC) $(LDFLAGS) $(OBJS) -o $(LIB)
 
 install: $(LIB)
-	mv $(EVROOT)/$(EVBIN) $(EVROOT)/$(EVBIN).original
-	install $(LAUNCHER) $(EVROOT)/$(EVBIN)
-	install $(LIB) $(EVROOT)
+        if [ ! -e $(EVROOT)/$(EVBIN_ORIG) ];\
+        then\
+                mv $(EVROOT)/$(EVBIN) $(EVROOT)/$(EVBIN_ORIG);\
+        fi;
+        install $(LAUNCHER) $(EVROOT)/$(EVBIN)
+        install $(LIB) $(EVROOT)
 
 uninstall:
-	mv $(EVROOT)/$(EVBIN).original $(EVROOT)/$(EVBIN)
-	rm -f $(EVROOT)/$(LIB)
+        mv $(EVROOT)/$(EVBIN).original $(EVROOT)/$(EVBIN)
+        rm -f $(EVROOT)/$(LIB)
 
 clean:
-	rm -rf $(OBJS)
+        rm -rf $(OBJS)


### PR DESCRIPTION
This code change will prevent the overwrite of the original binary, if you run "make install" a second time. I had to restore from a backup a moment ago... Ah well. :)
