### PR TITLE
Updated DYLD_INSERT_LIBRARIES to point at GLEngine in the OpenGL framework

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -3,7 +3,13 @@ WD=`dirname "$0"`
 EVBIN="Ev Nova"
 
 export DYLD_FORCE_FLAT_NAMESPACE=1
-export DYLD_INSERT_LIBRARIES="$WD/libNova.A.dylib:/System/Library/Frameworks/OpenGL.framework/Resources/GLEngine.bundle/GLEngine"
+
+if [ -e "/System/Library/Frameworks/OpenGL.framework/Resources/GLEngine.bundle/GLEngine" ]
+then
+	export DYLD_INSERT_LIBRARIES="$WD/libNova.A.dylib:/System/Library/Frameworks/OpenGL.framework/Resources/GLEngine.bundle/GLEngine"
+else
+	export DYLD_INSERT_LIBRARIES="$WD/libNova.A.dylib"
+fi
 
 if [ -e "$WD/$EVBIN.original" ]
 then

--- a/launcher.sh
+++ b/launcher.sh
@@ -3,7 +3,7 @@ WD=`dirname "$0"`
 EVBIN="Ev Nova"
 
 export DYLD_FORCE_FLAT_NAMESPACE=1
-export DYLD_INSERT_LIBRARIES="$WD/libNova.A.dylib"
+export DYLD_INSERT_LIBRARIES="$WD/libNova.A.dylib:/System/Library/Frameworks/OpenGL.framework/Resources/GLEngine.bundle/GLEngine"
 
 if [ -e "$WD/$EVBIN.original" ]
 then


### PR DESCRIPTION
after playing for some time, clicking on either the Continue button on the opening Registration prompt, or the Open Pilot button in the start menu, results in the following crash: 

dyld: lazy symbol binding failed: Symbol not found: _gliCreateContextWithShared
  Referenced from: /System/Library/Frameworks/OpenGL.framework/Resources/GLEngine.bundle/GLEngine
  Expected in: flat namespace

dyld: Symbol not found: _gliCreateContextWithShared
  Referenced from: /System/Library/Frameworks/OpenGL.framework/Resources/GLEngine.bundle/GLEngine
  Expected in: flat namespace

./launcher.sh: line 13:  2296 Trace/BPT trap: 5       "/Applications/EV Nova.app/Contents/MacOS/$EVBIN"

The solution is to apply the following to the DYLD_INSERT_LIBRARIES list:
http://stackoverflow.com/questions/22732381/dyld-symbol-not-found-but-nm-reports-otherwise-os-x-update-issue
